### PR TITLE
add extra header for volcano engine model provider

### DIFF
--- a/src/agents/models-config.providers.header.test.ts
+++ b/src/agents/models-config.providers.header.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { normalizeProviders } from "./models-config.providers.js";
+
+describe("normalizeProviders header injection", () => {
+  it("injects custom header when provider is volcengine", () => {
+    process.env.MODEL_AGENT_CLIENT_REQ_ID = "X-Target-Header";
+    process.env.MODEL_AGENT_CLIENT_REQ_VALUE = "target-value";
+
+    const providers = {
+      volcengine: {
+        baseUrl: "http://example.com",
+        models: [],
+        apiKey: "foo",
+      },
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir: "/tmp" });
+    expect(normalized?.volcengine?.headers?.["X-Target-Header"]).toBe("target-value");
+
+    delete process.env.MODEL_AGENT_CLIENT_REQ_ID;
+    delete process.env.MODEL_AGENT_CLIENT_REQ_VALUE;
+  });
+
+  it("does not inject header for non-volcengine providers", () => {
+    process.env.MODEL_AGENT_CLIENT_REQ_ID = "X-Target-Header";
+    process.env.MODEL_AGENT_CLIENT_REQ_VALUE = "target-value";
+
+    const providers = {
+      others: {
+        baseUrl: "http://example.com",
+        models: [],
+        apiKey: "foo",
+      },
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir: "/tmp" });
+    expect(normalized?.others?.headers?.["X-Target-Header"]).toBeUndefined();
+
+    delete process.env.MODEL_AGENT_CLIENT_REQ_ID;
+    delete process.env.MODEL_AGENT_CLIENT_REQ_VALUE;
+  });
+
+  it("does not inject header if only one env var is set (missing VALUE)", () => {
+    process.env.MODEL_AGENT_CLIENT_REQ_ID = "X-Incomplete";
+    // Missing VALUE
+
+    const providers = {
+      volcengine: {
+        baseUrl: "http://example.com",
+        models: [],
+        apiKey: "foo",
+      },
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir: "/tmp" });
+    expect(normalized?.volcengine?.headers?.["X-Incomplete"]).toBeUndefined();
+
+    delete process.env.MODEL_AGENT_CLIENT_REQ_ID;
+  });
+
+  it("preserves existing headers while adding custom header for volcengine", () => {
+    process.env.MODEL_AGENT_CLIENT_REQ_ID = "X-Added";
+    process.env.MODEL_AGENT_CLIENT_REQ_VALUE = "added-val";
+
+    const providers = {
+      volcengine: {
+        baseUrl: "http://example.com",
+        models: [],
+        apiKey: "foo",
+        headers: { "Existing-Header": "value" },
+      },
+    };
+    const normalized = normalizeProviders({ providers, agentDir: "/tmp" });
+    expect(normalized?.volcengine?.headers?.["X-Added"]).toBe("added-val");
+    expect(normalized?.volcengine?.headers?.["Existing-Header"]).toBe("value");
+
+    delete process.env.MODEL_AGENT_CLIENT_REQ_ID;
+    delete process.env.MODEL_AGENT_CLIENT_REQ_VALUE;
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -272,6 +272,25 @@ export function normalizeProviders(params: {
       normalizedProvider = googleNormalized;
     }
 
+    if (
+      normalizedKey === "volcengine" &&
+      process.env.MODEL_AGENT_CLIENT_REQ_ID &&
+      process.env.MODEL_AGENT_CLIENT_REQ_VALUE
+    ) {
+      const keyName = process.env.MODEL_AGENT_CLIENT_REQ_ID;
+      const valName = process.env.MODEL_AGENT_CLIENT_REQ_VALUE;
+      if (normalizedProvider.headers?.[keyName] !== valName) {
+        mutated = true;
+        normalizedProvider = {
+          ...normalizedProvider,
+          headers: {
+            ...normalizedProvider.headers,
+            [keyName]: valName,
+          },
+        };
+      }
+    }
+
     next[key] = normalizedProvider;
   }
 

--- a/src/commands/auth-choice.apply.volcengine.ts
+++ b/src/commands/auth-choice.apply.volcengine.ts
@@ -66,12 +66,17 @@ export async function applyAuthChoiceVolcengine(
   const verifyModelAccess = async (id: string): Promise<boolean> => {
     const verifySpin = params.prompter.progress(`Verifying access to ${id} (10s timeout)...`);
     try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      };
+      if (process.env.MODEL_AGENT_CLIENT_REQ_ID && process.env.MODEL_AGENT_CLIENT_REQ_VALUE) {
+        headers[process.env.MODEL_AGENT_CLIENT_REQ_ID] = process.env.MODEL_AGENT_CLIENT_REQ_VALUE;
+      }
+
       const res = await fetch(`${VOLCENGINE_API_BASE_URL}/chat/completions`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify({
           model: id,
           messages: [{ role: "user", content: "hi" }],


### PR DESCRIPTION
当model provider是火山引擎的时候，支持通过环境变量配置Extra Header（MODEL_AGENT_CLIENT_REQ_ID， MODEL_AGENT_CLIENT_REQ_VALUE），以标识调用方来源