### PR TITLE
docs: 翻译部分供应商文档为中文

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,31 +1,31 @@
 ---
-summary: "Use Anthropic Claude via API keys or Claude Code CLI auth in Clawdbot"
+summary: "在 Clawdbot 中通过 API 密钥或 Claude Code CLI 认证使用 Anthropic Claude"
 read_when:
-  - You want to use Anthropic models in Clawdbot
-  - You want setup-token or Claude Code CLI auth instead of API keys
+  - 您想在 Clawdbot 中使用 Anthropic 模型
+  - 您想用 setup-token 或 Claude Code CLI 认证而非 API 密钥
 ---
 # Anthropic (Claude)
 
-Anthropic builds the **Claude** model family and provides access via an API.
-In Clawdbot you can authenticate with an API key or reuse **Claude Code CLI** credentials
-(setup-token or OAuth).
+Anthropic 开发了 **Claude** 模型系列，并通过 API 提供访问。
+在 Clawdbot 中，您可以使用 API 密钥认证，或复用 **Claude Code CLI** 凭证
+（setup-token 或 OAuth）。
 
-## Option A: Anthropic API key
+## 方式 A：Anthropic API 密钥
 
-**Best for:** standard API access and usage-based billing.
-Create your API key in the Anthropic Console.
+**适用场景：** 标准 API 访问，按量计费。
+在 Anthropic Console 中创建 API 密钥。
 
-### CLI setup
+### CLI 配置
 
 ```bash
 openclaw-cn onboard
-# choose: Anthropic API key
+# 选择：Anthropic API key
 
-# or non-interactive
+# 或非交互式
 openclaw-cn onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 ```
 
-### Config snippet
+### 配置示例
 
 ```json5
 {
@@ -34,12 +34,12 @@ openclaw-cn onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 }
 ```
 
-## Prompt caching (Anthropic API)
+## Prompt 缓存（Anthropic API）
 
-Clawdbot does **not** override Anthropic’s default cache TTL unless you set it.
-This is **API-only**; Claude Code CLI OAuth ignores TTL settings.
+Clawdbot **不会**覆盖 Anthropic 的默认缓存 TTL，除非您手动设置。
+此功能仅适用于 **API 密钥**；Claude Code CLI OAuth 会忽略 TTL 设置。
 
-To set the TTL per model, use `cacheControlTtl` in the model `params`:
+按模型设置 TTL，使用 `cacheControlTtl`：
 
 ```json5
 {
@@ -47,7 +47,7 @@ To set the TTL per model, use `cacheControlTtl` in the model `params`:
     defaults: {
       models: {
         "anthropic/claude-opus-4-5": {
-          params: { cacheControlTtl: "5m" } // or "1h"
+          params: { cacheControlTtl: "5m" } // 或 "1h"
         }
       }
     }
@@ -55,41 +55,41 @@ To set the TTL per model, use `cacheControlTtl` in the model `params`:
 }
 ```
 
-Clawdbot includes the `extended-cache-ttl-2025-04-11` beta flag for Anthropic API
-requests; keep it if you override provider headers (see [/gateway/configuration](/gateway/configuration)).
+Clawdbot 在 Anthropic API 请求中包含 `extended-cache-ttl-2025-04-11` beta 标志；
+如果您覆盖了供应商 headers，请保留此标志（详见 [/gateway/configuration](/gateway/configuration)）。
 
-## Option B: Claude Code CLI (setup-token or OAuth)
+## 方式 B：Claude Code CLI（setup-token 或 OAuth）
 
-**Best for:** using your Claude subscription or existing Claude Code CLI login.
+**适用场景：** 使用您的 Claude 订阅或已有的 Claude Code CLI 登录。
 
-### Where to get a setup-token
+### 获取 setup-token
 
-Setup-tokens are created by the **Claude Code CLI**, not the Anthropic Console. You can run this on **any machine**:
+setup-token 由 **Claude Code CLI** 生成，不是在 Anthropic Console 中创建。可在**任何机器**上运行：
 
 ```bash
 claude setup-token
 ```
 
-Paste the token into Clawdbot (wizard: **Anthropic token (paste setup-token)**), or run it on the gateway host:
+将 token 粘贴到 Clawdbot（向导中选择 **Anthropic token (paste setup-token)**），或在网关主机上运行：
 
 ```bash
 openclaw-cn models auth setup-token --provider anthropic
 ```
 
-If you generated the token on a different machine, paste it:
+如果您在另一台机器上生成了 token，粘贴它：
 
 ```bash
 openclaw-cn models auth paste-token --provider anthropic
 ```
 
-### CLI setup
+### CLI 配置
 
 ```bash
-# Reuse Claude Code CLI OAuth credentials if already logged in
+# 复用 Claude Code CLI OAuth 凭证（如果已登录）
 openclaw-cn onboard --auth-choice claude-cli
 ```
 
-### Config snippet
+### 配置示例
 
 ```json5
 {
@@ -97,34 +97,31 @@ openclaw-cn onboard --auth-choice claude-cli
 }
 ```
 
-## Notes
+## 说明
 
-- Generate the setup-token with `claude setup-token` and paste it, or run `openclaw-cn models auth setup-token` on the gateway host.
-- If you see “OAuth token refresh failed …” on a Claude subscription, re-auth with a setup-token or resync Claude Code CLI OAuth on the gateway host. See [/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription](/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription).
-- Clawdbot writes `auth.profiles["anthropic:claude-cli"].mode` as `"oauth"` so the profile
-  accepts both OAuth and setup-token credentials. Older configs using `"token"` are
-  auto-migrated on load.
-- Auth details + reuse rules are in [/concepts/oauth](/concepts/oauth).
+- 使用 `claude setup-token` 生成 token 并粘贴，或在网关主机上运行 `openclaw-cn models auth setup-token`。
+- 如果看到 "OAuth token refresh failed ..." 错误（Claude 订阅），请重新用 setup-token 认证或在网关主机上重新同步 Claude Code CLI OAuth。详见 [/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription](/gateway/troubleshooting#oauth-token-refresh-failed-anthropic-claude-subscription)。
+- Clawdbot 将 `auth.profiles["anthropic:claude-cli"].mode` 设为 `"oauth"`，使配置文件同时接受 OAuth 和 setup-token 凭证。旧配置中的 `"token"` 在加载时会自动迁移。
+- 认证详情和复用规则见 [/concepts/oauth](/concepts/oauth)。
 
-## Troubleshooting
+## 故障排除
 
-**401 errors / token suddenly invalid**
-- Claude subscription auth can expire or be revoked. Re-run `claude setup-token`
-  and paste it into the **gateway host**.
-- If the Claude CLI login lives on a different machine, use
-  `openclaw-cn models auth paste-token --provider anthropic` on the gateway host.
+**401 错误 / token 突然失效**
+- Claude 订阅认证可能过期或被撤销。重新运行 `claude setup-token` 并粘贴到**网关主机**。
+- 如果 Claude CLI 登录在另一台机器上，在网关主机上使用
+  `openclaw-cn models auth paste-token --provider anthropic`。
 
 **No API key found for provider "anthropic"**
-- Auth is **per agent**. New agents don’t inherit the main agent’s keys.
-- Re-run onboarding for that agent, or paste a setup-token / API key on the
-  gateway host, then verify with `openclaw-cn models status`.
+- 认证是**按 agent 隔离的**。新 agent 不会继承主 agent 的密钥。
+- 为该 agent 重新运行 onboarding，或在网关主机上粘贴 setup-token / API 密钥，
+  然后用 `openclaw-cn models status` 验证。
 
 **No credentials found for profile `anthropic:default` or `anthropic:claude-cli`**
-- Run `openclaw-cn models status` to see which auth profile is active.
-- Re-run onboarding, or paste a setup-token / API key for that profile.
+- 运行 `openclaw-cn models status` 查看当前活跃的认证配置。
+- 重新运行 onboarding，或为该配置粘贴 setup-token / API 密钥。
 
 **No available auth profile (all in cooldown/unavailable)**
-- Check `openclaw-cn models status --json` for `auth.unusableProfiles`.
-- Add another Anthropic profile or wait for cooldown.
+- 检查 `openclaw-cn models status --json` 中的 `auth.unusableProfiles`。
+- 添加另一个 Anthropic 配置或等待冷却结束。
 
-More: [/gateway/troubleshooting](/gateway/troubleshooting) and [/help/faq](/help/faq).
+更多内容：[/gateway/troubleshooting](/gateway/troubleshooting) 和 [/help/faq](/help/faq)。

--- a/docs/providers/deepgram.md
+++ b/docs/providers/deepgram.md
@@ -1,29 +1,28 @@
 ---
-summary: "Deepgram transcription for inbound voice notes"
+summary: "Deepgram 语音转写（处理收到的语音消息）"
 read_when:
-  - You want Deepgram speech-to-text for audio attachments
-  - You need a quick Deepgram config example
+  - 您想用 Deepgram 对音频附件进行语音转文字
+  - 您需要 Deepgram 快速配置示例
 ---
-# Deepgram (Audio Transcription)
+# Deepgram（音频转写）
 
-Deepgram is a speech-to-text API. In Clawdbot it is used for **inbound audio/voice note
-transcription** via `tools.media.audio`.
+Deepgram 是一个语音转文字 API。在 Clawdbot 中，它通过 `tools.media.audio`
+用于**接收的音频/语音消息转写**。
 
-When enabled, Clawdbot uploads the audio file to Deepgram and injects the transcript
-into the reply pipeline (`{{Transcript}}` + `[Audio]` block). This is **not streaming**;
-it uses the pre-recorded transcription endpoint.
+启用后，Clawdbot 将音频文件上传到 Deepgram 并将转写结果注入回复管道
+（`{{Transcript}}` + `[Audio]` 块）。这**不是流式转写**，使用的是预录音转写端点。
 
-Website: https://deepgram.com  
-Docs: https://developers.deepgram.com
+官网：https://deepgram.com
+文档：https://developers.deepgram.com
 
-## Quick start
+## 快速开始
 
-1) Set your API key:
+1) 设置 API 密钥：
 ```
 DEEPGRAM_API_KEY=dg_...
 ```
 
-2) Enable the provider:
+2) 启用供应商：
 ```json5
 {
   tools: {
@@ -37,15 +36,15 @@ DEEPGRAM_API_KEY=dg_...
 }
 ```
 
-## Options
+## 选项
 
-- `model`: Deepgram model id (default: `nova-3`)
-- `language`: language hint (optional)
-- `tools.media.audio.providerOptions.deepgram.detect_language`: enable language detection (optional)
-- `tools.media.audio.providerOptions.deepgram.punctuate`: enable punctuation (optional)
-- `tools.media.audio.providerOptions.deepgram.smart_format`: enable smart formatting (optional)
+- `model`：Deepgram 模型 ID（默认：`nova-3`）
+- `language`：语言提示（可选）
+- `tools.media.audio.providerOptions.deepgram.detect_language`：启用语言检测（可选）
+- `tools.media.audio.providerOptions.deepgram.punctuate`：启用标点符号（可选）
+- `tools.media.audio.providerOptions.deepgram.smart_format`：启用智能格式化（可选）
 
-Example with language:
+指定语言示例：
 ```json5
 {
   tools: {
@@ -53,7 +52,7 @@ Example with language:
       audio: {
         enabled: true,
         models: [
-          { provider: "deepgram", model: "nova-3", language: "en" }
+          { provider: "deepgram", model: "nova-3", language: "zh" }
         ]
       }
     }
@@ -61,7 +60,7 @@ Example with language:
 }
 ```
 
-Example with Deepgram options:
+带 Deepgram 选项示例：
 ```json5
 {
   tools: {
@@ -82,8 +81,8 @@ Example with Deepgram options:
 }
 ```
 
-## Notes
+## 说明
 
-- Authentication follows the standard provider auth order; `DEEPGRAM_API_KEY` is the simplest path.
-- Override endpoints or headers with `tools.media.audio.baseUrl` and `tools.media.audio.headers` when using a proxy.
-- Output follows the same audio rules as other providers (size caps, timeouts, transcript injection).
+- 认证遵循标准供应商认证顺序；`DEEPGRAM_API_KEY` 是最简单的方式。
+- 使用代理时，可通过 `tools.media.audio.baseUrl` 和 `tools.media.audio.headers` 覆盖端点或 headers。
+- 输出遵循与其他供应商相同的音频规则（大小限制、超时、转写注入）。

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -1,59 +1,52 @@
 ---
-summary: "Sign in to GitHub Copilot from Clawdbot using the device flow"
+summary: "在 Clawdbot 中通过设备流程登录 GitHub Copilot"
 read_when:
-  - You want to use GitHub Copilot as a model provider
-  - You need the `openclaw-cn models auth login-github-copilot` flow
+  - 您想使用 GitHub Copilot 作为模型供应商
+  - 您需要 `openclaw-cn models auth login-github-copilot` 流程
 ---
-# Github Copilot
+# GitHub Copilot
 
-## What is GitHub Copilot?
+## 什么是 GitHub Copilot
 
-GitHub Copilot is GitHub's AI coding assistant. It provides access to Copilot
-models for your GitHub account and plan. Clawdbot can use Copilot as a model
-provider in two different ways.
+GitHub Copilot 是 GitHub 的 AI 编程助手，根据您的 GitHub 账户和订阅计划提供
+Copilot 模型的访问权限。Clawdbot 支持两种方式使用 Copilot。
 
-## Two ways to use Copilot in Clawdbot
+## 两种使用方式
 
-### 1) Built-in GitHub Copilot provider (`github-copilot`)
+### 1) 内置 GitHub Copilot 供应商 (`github-copilot`)
 
-Use the native device-login flow to obtain a GitHub token, then exchange it for
-Copilot API tokens when Clawdbot runs. This is the **default** and simplest path
-because it does not require VS Code.
+使用原生设备登录流程获取 GitHub token，然后在 Clawdbot 运行时兑换为
+Copilot API token。这是**默认且最简单**的方式，不需要 VS Code。
 
-### 2) Copilot Proxy plugin (`copilot-proxy`)
+### 2) Copilot Proxy 插件 (`copilot-proxy`)
 
-Use the **Copilot Proxy** VS Code extension as a local bridge. Clawdbot talks to
-the proxy’s `/v1` endpoint and uses the model list you configure there. Choose
-this when you already run Copilot Proxy in VS Code or need to route through it.
-You must enable the plugin and keep the VS Code extension running.
+使用 **Copilot Proxy** VS Code 扩展作为本地桥接。Clawdbot 连接到代理的
+`/v1` 端点，使用您在扩展中配置的模型列表。如果您已经在 VS Code 中运行
+Copilot Proxy 或需要通过它路由，请选择此方式。需要启用插件并保持 VS Code
+扩展运行。
 
-Use GitHub Copilot as a model provider (`github-copilot`). The login command runs
-the GitHub device flow, saves an auth profile, and updates your config to use that
-profile.
-
-## CLI setup
+## CLI 配置
 
 ```bash
 openclaw-cn models auth login-github-copilot
 ```
 
-You'll be prompted to visit a URL and enter a one-time code. Keep the terminal
-open until it completes.
+系统会提示您访问一个 URL 并输入一次性代码。在完成之前请保持终端打开。
 
-### Optional flags
+### 可选参数
 
 ```bash
 openclaw-cn models auth login-github-copilot --profile-id github-copilot:work
 openclaw-cn models auth login-github-copilot --yes
 ```
 
-## Set a default model
+## 设置默认模型
 
 ```bash
 openclaw-cn models set github-copilot/gpt-4o
 ```
 
-### Config snippet
+### 配置示例
 
 ```json5
 {
@@ -61,10 +54,10 @@ openclaw-cn models set github-copilot/gpt-4o
 }
 ```
 
-## Notes
+## 说明
 
-- Requires an interactive TTY; run it directly in a terminal.
-- Copilot model availability depends on your plan; if a model is rejected, try
-  another ID (for example `github-copilot/gpt-4.1`).
-- The login stores a GitHub token in the auth profile store and exchanges it for a
-  Copilot API token when Clawdbot runs.
+- 需要交互式终端（TTY），请直接在终端中运行。
+- Copilot 可用的模型取决于您的订阅计划；如果某个模型被拒绝，请尝试
+  其他 ID（例如 `github-copilot/gpt-4.1`）。
+- 登录后会将 GitHub token 存储在认证配置中，Clawdbot 运行时兑换为
+  Copilot API token。

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,29 +1,28 @@
 ---
-summary: "Model providers (LLMs) supported by Clawdbot"
+summary: "Clawdbot 支持的模型供应商（LLM）"
 read_when:
-  - You want to choose a model provider
-  - You need a quick overview of supported LLM backends
+  - 您想选择一个模型供应商
+  - 您需要快速了解支持的 LLM 后端
 ---
-# Model Providers
+# 模型供应商
 
-Clawdbot can use many LLM providers. Pick a provider, authenticate, then set the
-default model as `provider/model`.
+Clawdbot 支持多种 LLM 供应商。选择供应商、完成认证，然后将默认模型设为 `provider/model` 即可。
 
-Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/channels).
+如果您在找聊天渠道文档（WhatsApp / Telegram / Discord / Slack / Mattermost（插件）等），请查看 [渠道](/channels)。
 
-## Highlight: Venius (Venice AI)
+## 推荐：Venius (Venice AI)
 
-Venius is our recommended Venice AI setup for privacy-first inference with an option to use Opus for hard tasks.
+Venius 是我们推荐的 Venice AI 配置方案，提供隐私优先的推理，并可选用 Opus 处理高难度任务。
 
-- Default: `venice/llama-3.3-70b`
-- Best overall: `venice/claude-opus-45` (Opus remains the strongest)
+- 默认模型：`venice/llama-3.3-70b`
+- 最佳综合：`venice/claude-opus-45`（Opus 仍然是最强的）
 
-See [Venice AI](/providers/venice).
+详见 [Venice AI](/providers/venice)。
 
-## Quick start
+## 快速开始
 
-1) Authenticate with the provider (usually via `openclaw-cn onboard`).
-2) Set the default model:
+1) 通过供应商完成认证（通常运行 `openclaw-cn onboard`）。
+2) 设置默认模型：
 
 ```json5
 {
@@ -31,30 +30,29 @@ See [Venice AI](/providers/venice).
 }
 ```
 
-## Provider docs
+## 供应商文档
 
-- [OpenAI (API + Codex)](/providers/openai)
-- [Anthropic (API + Claude Code CLI)](/providers/anthropic)
-- [Qwen (OAuth)](/providers/qwen)
+- [OpenAI（API + Codex）](/providers/openai)
+- [Anthropic（API + Claude Code CLI）](/providers/anthropic)
+- [Qwen（通义千问，OAuth）](/providers/qwen)
 - [OpenRouter](/providers/openrouter)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
-- [Moonshot AI (Kimi + Kimi Code)](/providers/moonshot)
+- [Moonshot AI（月之暗面）/ Kimi + Kimi Code](/providers/moonshot)
 - [OpenCode Zen](/providers/opencode)
 - [Amazon Bedrock](/bedrock)
-- [Z.AI](/providers/zai)
-- [GLM models](/providers/glm)
+- [Z.AI（智谱）](/providers/zai)
+- [GLM 模型](/providers/glm)
 - [MiniMax](/providers/minimax)
-- [Volcengine (火山引擎/豆包)](/providers/volcengine)
-- [Venius (Venice AI, privacy-focused)](/providers/venice)
-- [Ollama (local models)](/providers/ollama)
+- [火山引擎 / 豆包](/providers/volcengine)
+- [Venius（Venice AI，隐私优先）](/providers/venice)
+- [Ollama（本地模型）](/providers/ollama)
 
-## Transcription providers
+## 语音转写供应商
 
-- [Deepgram (audio transcription)](/providers/deepgram)
+- [Deepgram（音频转写）](/providers/deepgram)
 
-## Community tools
+## 社区工具
 
-- [Claude Max API Proxy](/providers/claude-max-api-proxy) - Use Claude Max/Pro subscription as an OpenAI-compatible API endpoint
+- [Claude Max API Proxy](/providers/claude-max-api-proxy) - 将 Claude Max/Pro 订阅用作 OpenAI 兼容 API 端点
 
-For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
-see [Model providers](/concepts/model-providers).
+完整供应商目录（xAI、Groq、Mistral 等）及高级配置，请查看[模型供应商](/concepts/model-providers)。

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -1,18 +1,17 @@
 ---
-summary: "Configure Moonshot K2 vs Kimi Code (separate providers + keys)"
+summary: "配置 Moonshot（月之暗面）K2 与 Kimi Code（独立供应商和密钥）"
 read_when:
-  - You want Moonshot K2 (Moonshot Open Platform) vs Kimi Code setup
-  - You need to understand separate endpoints, keys, and model refs
-  - You want copy/paste config for either provider
+  - 您想配置 Moonshot（月之暗面）K2 或 Kimi Code
+  - 您需要了解它们各自的端点、密钥和模型引用
+  - 您需要可直接复制的配置示例
 ---
 
-# Moonshot AI (Kimi)
+# Moonshot AI（月之暗面）/ Kimi
 
-Moonshot provides the Kimi API with OpenAI-compatible endpoints. Configure the
-provider and set the default model to `moonshot/kimi-k2-0905-preview`, or use
-Kimi Code with `kimi-code/kimi-for-coding`.
+Moonshot（月之暗面）提供 Kimi API，兼容 OpenAI 接口格式。配置供应商后将默认模型
+设为 `moonshot/kimi-k2-0905-preview`，或使用 Kimi Code 的 `kimi-code/kimi-for-coding`。
 
-Current Kimi K2 model IDs:
+当前 Kimi K2 模型 ID：
 {/* moonshot-kimi-k2-ids:start */}
 - `kimi-k2-0905-preview`
 - `kimi-k2-turbo-preview`
@@ -24,15 +23,18 @@ Current Kimi K2 model IDs:
 openclaw-cn onboard --auth-choice moonshot-api-key
 ```
 
-Kimi Code:
+Kimi Code：
 
 ```bash
 openclaw-cn onboard --auth-choice kimi-code-api-key
 ```
 
-Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeable, endpoints differ, and model refs differ (Moonshot uses `moonshot/...`, Kimi Code uses `kimi-code/...`).
+注意：Moonshot（月之暗面）和 Kimi Code 是**两个独立的供应商**。API 密钥不互通，端点不同，模型引用也不同（Moonshot 使用 `moonshot/...`，Kimi Code 使用 `kimi-code/...`）。
 
-## Config snippet (Moonshot API)
+## 配置示例（Moonshot API）
+
+> **国内用户请注意：** 下方配置默认使用国内端点 `api.moonshot.cn`。
+> 海外用户如需使用国际端点，请将 `baseUrl` 改为 `https://api.moonshot.ai/v1`。
 
 ```json5
 {
@@ -54,7 +56,8 @@ Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeabl
     mode: "merge",
     providers: {
       moonshot: {
-        baseUrl: "https://api.moonshot.ai/v1",
+        // 国内端点（默认）；海外用户请改为 https://api.moonshot.ai/v1
+        baseUrl: "https://api.moonshot.cn/v1",
         apiKey: "${MOONSHOT_API_KEY}",
         api: "openai-completions",
         models: [
@@ -142,10 +145,10 @@ Note: Moonshot and Kimi Code are separate providers. Keys are not interchangeabl
 }
 ```
 
-## Notes
+## 说明
 
-- Moonshot model refs use `moonshot/<modelId>`. Kimi Code model refs use `kimi-code/<modelId>`.
-- Override pricing and context metadata in `models.providers` if needed.
-- If Moonshot publishes different context limits for a model, adjust
-  `contextWindow` accordingly.
-- Use `https://api.moonshot.cn/v1` if you need the China endpoint.
+- Moonshot（月之暗面）模型引用格式为 `moonshot/<modelId>`，Kimi Code 模型引用格式为 `kimi-code/<modelId>`。
+- 如需自定义定价和上下文元数据，可在 `models.providers` 中覆盖。
+- 如果 Moonshot（月之暗面）发布了不同的上下文长度限制，请相应调整 `contextWindow`。
+- **国内端点：** `https://api.moonshot.cn/v1`（本文档默认）
+- **海外端点：** `https://api.moonshot.ai/v1`

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,30 +1,30 @@
 ---
-summary: "Use OpenAI via API keys or Codex subscription in Clawdbot"
+summary: "在 Clawdbot 中通过 API 密钥或 Codex 订阅使用 OpenAI"
 read_when:
-  - You want to use OpenAI models in Clawdbot
-  - You want Codex subscription auth instead of API keys
+  - 您想在 Clawdbot 中使用 OpenAI 模型
+  - 您想用 Codex 订阅认证而非 API 密钥
 ---
 # OpenAI
 
-OpenAI provides developer APIs for GPT models. Codex supports **ChatGPT sign-in** for subscription
-access or **API key** sign-in for usage-based access. Codex cloud requires ChatGPT sign-in, while
-the Codex CLI supports either sign-in method. The Codex CLI caches login details in
-`~/.codex/auth.json` (or your OS credential store), which Clawdbot can reuse.
+OpenAI 提供 GPT 系列模型的开发者 API。Codex 支持通过 **ChatGPT 登录**使用订阅访问，
+或通过 **API 密钥**使用按量计费访问。Codex 云端需要 ChatGPT 登录，而 Codex CLI 两种
+方式都支持。Codex CLI 会将登录信息缓存到 `~/.codex/auth.json`（或系统凭证存储），
+Clawdbot 可以复用这些凭证。
 
-## Option A: OpenAI API key (OpenAI Platform)
+## 方式 A：OpenAI API 密钥（OpenAI Platform）
 
-**Best for:** direct API access and usage-based billing.
-Get your API key from the OpenAI dashboard.
+**适用场景：** 直接 API 访问，按量计费。
+从 OpenAI 控制台获取 API 密钥。
 
-### CLI setup
+### CLI 配置
 
 ```bash
 openclaw-cn onboard --auth-choice openai-api-key
-# or non-interactive
+# 或非交互式
 openclaw-cn onboard --openai-api-key "$OPENAI_API_KEY"
 ```
 
-### Config snippet
+### 配置示例
 
 ```json5
 {
@@ -33,24 +33,24 @@ openclaw-cn onboard --openai-api-key "$OPENAI_API_KEY"
 }
 ```
 
-## Option B: OpenAI Code (Codex) subscription
+## 方式 B：OpenAI Code (Codex) 订阅
 
-**Best for:** using ChatGPT/Codex subscription access instead of an API key.
-Codex cloud requires ChatGPT sign-in, while the Codex CLI supports ChatGPT or API key sign-in.
+**适用场景：** 使用 ChatGPT/Codex 订阅访问，而非 API 密钥。
+Codex 云端需要 ChatGPT 登录，Codex CLI 支持 ChatGPT 或 API 密钥登录。
 
-Clawdbot can reuse your **Codex CLI** login (`~/.codex/auth.json`) or run the OAuth flow.
+Clawdbot 可以复用您的 **Codex CLI** 登录凭证（`~/.codex/auth.json`）或执行 OAuth 流程。
 
-### CLI setup
+### CLI 配置
 
 ```bash
-# Reuse existing Codex CLI login
+# 复用已有的 Codex CLI 登录
 openclaw-cn onboard --auth-choice codex-cli
 
-# Or run Codex OAuth in the wizard
+# 或在引导向导中执行 Codex OAuth
 openclaw-cn onboard --auth-choice openai-codex
 ```
 
-### Config snippet
+### 配置示例
 
 ```json5
 {
@@ -58,7 +58,7 @@ openclaw-cn onboard --auth-choice openai-codex
 }
 ```
 
-## Notes
+## 说明
 
-- Model refs always use `provider/model` (see [/concepts/models](/concepts/models)).
-- Auth details + reuse rules are in [/concepts/oauth](/concepts/oauth).
+- 模型引用格式始终为 `provider/model`（详见 [/concepts/models](/concepts/models)）。
+- 认证详情和复用规则见 [/concepts/oauth](/concepts/oauth)。

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -1,24 +1,24 @@
 ---
-summary: "Use OpenCode Zen (curated models) with Clawdbot"
+summary: "在 Clawdbot 中使用 OpenCode Zen（精选模型）"
 read_when:
-  - You want OpenCode Zen for model access
-  - You want a curated list of coding-friendly models
+  - 您想通过 OpenCode Zen 访问模型
+  - 您想要一个精选的编程友好模型列表
 ---
 # OpenCode Zen
 
-OpenCode Zen is a **curated list of models** recommended by the OpenCode team for coding agents.
-It is an optional, hosted model access path that uses an API key and the `opencode` provider.
-Zen is currently in beta.
+OpenCode Zen 是由 OpenCode 团队推荐的**精选编程模型列表**。
+它是一个可选的托管模型访问方式，使用 API 密钥和 `opencode` 供应商。
+Zen 目前处于 Beta 阶段。
 
-## CLI setup
+## CLI 配置
 
 ```bash
 openclaw-cn onboard --auth-choice opencode-zen
-# or non-interactive
+# 或非交互式
 openclaw-cn onboard --opencode-zen-api-key "$OPENCODE_API_KEY"
 ```
 
-## Config snippet
+## 配置示例
 
 ```json5
 {
@@ -27,8 +27,8 @@ openclaw-cn onboard --opencode-zen-api-key "$OPENCODE_API_KEY"
 }
 ```
 
-## Notes
+## 说明
 
-- `OPENCODE_ZEN_API_KEY` is also supported.
-- You sign in to Zen, add billing details, and copy your API key.
-- OpenCode Zen bills per request; check the OpenCode dashboard for details.
+- 也支持 `OPENCODE_ZEN_API_KEY` 环境变量。
+- 登录 Zen 后添加账单信息，然后复制 API 密钥即可使用。
+- OpenCode Zen 按请求计费，详情请查看 OpenCode 控制台。

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -1,21 +1,22 @@
 ---
-summary: "Use OpenRouter's unified API to access many models in Clawdbot"
+summary: "在 Clawdbot 中通过 OpenRouter 统一 API 访问多种模型"
 read_when:
-  - You want a single API key for many LLMs
-  - You want to run models via OpenRouter in Clawdbot
+  - 您想用一个 API 密钥访问多种 LLM
+  - 您想在 Clawdbot 中通过 OpenRouter 使用模型
 ---
 # OpenRouter
 
-OpenRouter provides a **unified API** that routes requests to many models behind a single
-endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by switching the base URL.
+OpenRouter 是一个**统一的模型 API 网关**，通过单一端点和 API 密钥将请求路由到多种模型（Claude、GPT、Gemini、Llama、DeepSeek 等）。它兼容 OpenAI API 格式，大多数 OpenAI SDK 只需切换 base URL 即可使用。
 
-## CLI setup
+OpenRouter 对国内用户特别友好：**支持支付宝 (Alipay) 充值**，无需国际信用卡即可使用海外主流模型。
+
+## CLI 配置
 
 ```bash
 openclaw-cn onboard --auth-choice apiKey --token-provider openrouter --token "$OPENROUTER_API_KEY"
 ```
 
-## Config snippet
+## 配置示例
 
 ```json5
 {
@@ -28,8 +29,8 @@ openclaw-cn onboard --auth-choice apiKey --token-provider openrouter --token "$O
 }
 ```
 
-## Notes
+## 说明
 
-- Model refs are `openrouter/<provider>/<model>`.
-- For more model/provider options, see [/concepts/model-providers](/concepts/model-providers).
-- OpenRouter uses a Bearer token with your API key under the hood.
+- 模型引用格式为 `openrouter/<provider>/<model>`。
+- 更多模型和供应商选项见 [/concepts/model-providers](/concepts/model-providers)。
+- OpenRouter 底层使用 Bearer token 配合您的 API 密钥进行认证。

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -1,71 +1,71 @@
 ---
-summary: "Use Venice AI privacy-focused models in Clawdbot"
+summary: "在 Clawdbot 中使用 Venice AI 隐私优先模型"
 read_when:
-  - You want privacy-focused inference in Clawdbot
-  - You want Venice AI setup guidance
+  - 您想在 Clawdbot 中使用隐私优先的推理
+  - 您需要 Venice AI 配置指南
 ---
-# Venice AI (Venius highlight)
+# Venice AI（Venius 推荐方案）
 
-**Venius** is our highlight Venice setup for privacy-first inference with optional anonymized access to proprietary models.
+**Venius** 是我们推荐的 Venice 配置方案，提供隐私优先的推理，并可选择通过匿名代理访问主流商业模型。
 
-Venice AI provides privacy-focused AI inference with support for uncensored models and access to major proprietary models through their anonymized proxy. All inference is private by default—no training on your data, no logging.
+Venice AI 提供隐私优先的 AI 推理服务，支持无审查模型，以及通过匿名代理访问主流商业模型。所有推理默认私密——不会用您的数据训练，不记录日志。
 
-## Why Venice in Clawdbot
+## 为什么选择 Venice
 
-- **Private inference** for open-source models (no logging).
-- **Uncensored models** when you need them.
-- **Anonymized access** to proprietary models (Opus/GPT/Gemini) when quality matters.
-- OpenAI-compatible `/v1` endpoints.
+- **私密推理** — 开源模型完全不记录日志
+- **无审查模型** — 在需要时使用
+- **匿名访问** — 通过代理使用商业模型（Opus/GPT/Gemini），元数据被剥离
+- 兼容 OpenAI `/v1` 端点
 
-## Privacy Modes
+## 隐私模式
 
-Venice offers two privacy levels — understanding this is key to choosing your model:
+Venice 提供两种隐私级别，选择模型时需要了解：
 
-| Mode | Description | Models |
-|------|-------------|--------|
-| **Private** | Fully private. Prompts/responses are **never stored or logged**. Ephemeral. | Llama, Qwen, DeepSeek, Venice Uncensored, etc. |
-| **Anonymized** | Proxied through Venice with metadata stripped. The underlying provider (OpenAI, Anthropic) sees anonymized requests. | Claude, GPT, Gemini, Grok, Kimi, MiniMax |
+| 模式 | 说明 | 适用模型 |
+|------|------|---------|
+| **私密 (Private)** | 完全私密。提示和回复**永不存储或记录**。 | Llama、Qwen、DeepSeek、Venice Uncensored 等 |
+| **匿名 (Anonymized)** | 通过 Venice 代理转发，元数据被剥离。底层供应商（OpenAI、Anthropic）看到的是匿名请求。 | Claude、GPT、Gemini、Grok、Kimi、MiniMax |
 
-## Features
+## 功能特性
 
-- **Privacy-focused**: Choose between "private" (fully private) and "anonymized" (proxied) modes
-- **Uncensored models**: Access to models without content restrictions
-- **Major model access**: Use Claude, GPT-5.2, Gemini, Grok via Venice's anonymized proxy
-- **OpenAI-compatible API**: Standard `/v1` endpoints for easy integration
-- **Streaming**: ✅ Supported on all models
-- **Function calling**: ✅ Supported on select models (check model capabilities)
-- **Vision**: ✅ Supported on models with vision capability
-- **No hard rate limits**: Fair-use throttling may apply for extreme usage
+- **隐私优先**：可选"私密"（完全私密）或"匿名"（代理转发）模式
+- **无审查模型**：可访问无内容限制的模型
+- **主流模型访问**：通过 Venice 匿名代理使用 Claude、GPT-5.2、Gemini、Grok
+- **OpenAI 兼容 API**：标准 `/v1` 端点，易于集成
+- **流式传输**：所有模型支持
+- **函数调用**：部分模型支持（查看模型功能）
+- **视觉理解**：支持视觉功能的模型可用
+- **无硬性速率限制**：极端使用量下可能有公平使用限流
 
-## Setup
+## 配置
 
-### 1. Get API Key
+### 1. 获取 API 密钥
 
-1. Sign up at [venice.ai](https://venice.ai)
-2. Go to **Settings → API Keys → Create new key**
-3. Copy your API key (format: `vapi_xxxxxxxxxxxx`)
+1. 在 [venice.ai](https://venice.ai) 注册
+2. 前往 **Settings → API Keys → Create new key**
+3. 复制 API 密钥（格式：`vapi_xxxxxxxxxxxx`）
 
-### 2. Configure Clawdbot
+### 2. 配置 Clawdbot
 
-**Option A: Environment Variable**
+**方式 A：环境变量**
 
 ```bash
 export VENICE_API_KEY="vapi_xxxxxxxxxxxx"
 ```
 
-**Option B: Interactive Setup (Recommended)**
+**方式 B：交互式配置（推荐）**
 
 ```bash
 openclaw-cn onboard --auth-choice venice-api-key
 ```
 
-This will:
-1. Prompt for your API key (or use existing `VENICE_API_KEY`)
-2. Show all available Venice models
-3. Let you pick your default model
-4. Configure the provider automatically
+这将：
+1. 提示输入 API 密钥（或使用已有的 `VENICE_API_KEY`）
+2. 显示所有可用的 Venice 模型
+3. 让您选择默认模型
+4. 自动配置供应商
 
-**Option C: Non-interactive**
+**方式 C：非交互式**
 
 ```bash
 openclaw-cn onboard --non-interactive \
@@ -73,160 +73,160 @@ openclaw-cn onboard --non-interactive \
   --venice-api-key "vapi_xxxxxxxxxxxx"
 ```
 
-### 3. Verify Setup
+### 3. 验证配置
 
 ```bash
 clawdbot chat --model venice/llama-3.3-70b "Hello, are you working?"
 ```
 
-## Model Selection
+## 模型选择
 
-After setup, Clawdbot shows all available Venice models. Pick based on your needs:
+配置完成后，Clawdbot 会显示所有可用的 Venice 模型。根据需求选择：
 
-- **Default (our pick)**: `venice/llama-3.3-70b` for private, balanced performance.
-- **Best overall quality**: `venice/claude-opus-45` for hard jobs (Opus remains the strongest).
-- **Privacy**: Choose "private" models for fully private inference.
-- **Capability**: Choose "anonymized" models to access Claude, GPT, Gemini via Venice's proxy.
+- **默认推荐**：`venice/llama-3.3-70b` — 私密，性能均衡
+- **最佳综合质量**：`venice/claude-opus-45` — 适合高难度任务（Opus 仍然最强）
+- **隐私优先**：选择"私密"模型，完全不记录日志
+- **能力优先**：选择"匿名"模型，通过 Venice 代理访问 Claude、GPT、Gemini
 
-Change your default model anytime:
+随时切换默认模型：
 
 ```bash
 openclaw-cn models set venice/claude-opus-45
 openclaw-cn models set venice/llama-3.3-70b
 ```
 
-List all available models:
+列出所有可用模型：
 
 ```bash
 openclaw-cn models list | grep venice
 ```
 
-## Configure via `clawdbot configure`
+## 通过 `clawdbot configure` 配置
 
-1. Run `clawdbot configure`
-2. Select **Model/auth**
-3. Choose **Venice AI**
+1. 运行 `clawdbot configure`
+2. 选择 **Model/auth**
+3. 选择 **Venice AI**
 
-## Which Model Should I Use?
+## 模型推荐
 
-| Use Case | Recommended Model | Why |
-|----------|-------------------|-----|
-| **General chat** | `llama-3.3-70b` | Good all-around, fully private |
-| **Best overall quality** | `claude-opus-45` | Opus remains the strongest for hard tasks |
-| **Privacy + Claude quality** | `claude-opus-45` | Best reasoning via anonymized proxy |
-| **Coding** | `qwen3-coder-480b-a35b-instruct` | Code-optimized, 262k context |
-| **Vision tasks** | `qwen3-vl-235b-a22b` | Best private vision model |
-| **Uncensored** | `venice-uncensored` | No content restrictions |
-| **Fast + cheap** | `qwen3-4b` | Lightweight, still capable |
-| **Complex reasoning** | `deepseek-v3.2` | Strong reasoning, private |
+| 使用场景 | 推荐模型 | 原因 |
+|---------|---------|------|
+| **日常对话** | `llama-3.3-70b` | 综合表现好，完全私密 |
+| **最佳综合质量** | `claude-opus-45` | Opus 处理高难度任务最强 |
+| **隐私 + Claude 质量** | `claude-opus-45` | 通过匿名代理获得最佳推理 |
+| **编程** | `qwen3-coder-480b-a35b-instruct` | 代码优化，262k 上下文 |
+| **视觉任务** | `qwen3-vl-235b-a22b` | 最佳私密视觉模型 |
+| **无审查** | `venice-uncensored` | 无内容限制 |
+| **快速低成本** | `qwen3-4b` | 轻量级，仍有不错能力 |
+| **复杂推理** | `deepseek-v3.2` | 强推理能力，私密 |
 
-## Available Models (25 Total)
+## 可用模型（共 25 个）
 
-### Private Models (15) — Fully Private, No Logging
+### 私密模型（15 个）— 完全私密，不记录日志
 
-| Model ID | Name | Context (tokens) | Features |
-|----------|------|------------------|----------|
-| `llama-3.3-70b` | Llama 3.3 70B | 131k | General |
-| `llama-3.2-3b` | Llama 3.2 3B | 131k | Fast, lightweight |
-| `hermes-3-llama-3.1-405b` | Hermes 3 Llama 3.1 405B | 131k | Complex tasks |
-| `qwen3-235b-a22b-thinking-2507` | Qwen3 235B Thinking | 131k | Reasoning |
-| `qwen3-235b-a22b-instruct-2507` | Qwen3 235B Instruct | 131k | General |
-| `qwen3-coder-480b-a35b-instruct` | Qwen3 Coder 480B | 262k | Code |
-| `qwen3-next-80b` | Qwen3 Next 80B | 262k | General |
-| `qwen3-vl-235b-a22b` | Qwen3 VL 235B | 262k | Vision |
-| `qwen3-4b` | Venice Small (Qwen3 4B) | 32k | Fast, reasoning |
-| `deepseek-v3.2` | DeepSeek V3.2 | 163k | Reasoning |
-| `venice-uncensored` | Venice Uncensored | 32k | Uncensored |
-| `mistral-31-24b` | Venice Medium (Mistral) | 131k | Vision |
-| `google-gemma-3-27b-it` | Gemma 3 27B Instruct | 202k | Vision |
-| `openai-gpt-oss-120b` | OpenAI GPT OSS 120B | 131k | General |
-| `zai-org-glm-4.7` | GLM 4.7 | 202k | Reasoning, multilingual |
+| 模型 ID | 名称 | 上下文（tokens） | 特性 |
+|---------|------|-----------------|------|
+| `llama-3.3-70b` | Llama 3.3 70B | 131k | 通用 |
+| `llama-3.2-3b` | Llama 3.2 3B | 131k | 快速轻量 |
+| `hermes-3-llama-3.1-405b` | Hermes 3 Llama 3.1 405B | 131k | 复杂任务 |
+| `qwen3-235b-a22b-thinking-2507` | Qwen3 235B Thinking | 131k | 推理 |
+| `qwen3-235b-a22b-instruct-2507` | Qwen3 235B Instruct | 131k | 通用 |
+| `qwen3-coder-480b-a35b-instruct` | Qwen3 Coder 480B | 262k | 编程 |
+| `qwen3-next-80b` | Qwen3 Next 80B | 262k | 通用 |
+| `qwen3-vl-235b-a22b` | Qwen3 VL 235B | 262k | 视觉 |
+| `qwen3-4b` | Venice Small (Qwen3 4B) | 32k | 快速推理 |
+| `deepseek-v3.2` | DeepSeek V3.2 | 163k | 推理 |
+| `venice-uncensored` | Venice Uncensored | 32k | 无审查 |
+| `mistral-31-24b` | Venice Medium (Mistral) | 131k | 视觉 |
+| `google-gemma-3-27b-it` | Gemma 3 27B Instruct | 202k | 视觉 |
+| `openai-gpt-oss-120b` | OpenAI GPT OSS 120B | 131k | 通用 |
+| `zai-org-glm-4.7` | GLM 4.7 | 202k | 推理、多语言 |
 
-### Anonymized Models (10) — Via Venice Proxy
+### 匿名模型（10 个）— 通过 Venice 代理
 
-| Model ID | Original | Context (tokens) | Features |
-|----------|----------|------------------|----------|
-| `claude-opus-45` | Claude Opus 4.5 | 202k | Reasoning, vision |
-| `claude-sonnet-45` | Claude Sonnet 4.5 | 202k | Reasoning, vision |
-| `openai-gpt-52` | GPT-5.2 | 262k | Reasoning |
-| `openai-gpt-52-codex` | GPT-5.2 Codex | 262k | Reasoning, vision |
-| `gemini-3-pro-preview` | Gemini 3 Pro | 202k | Reasoning, vision |
-| `gemini-3-flash-preview` | Gemini 3 Flash | 262k | Reasoning, vision |
-| `grok-41-fast` | Grok 4.1 Fast | 262k | Reasoning, vision |
-| `grok-code-fast-1` | Grok Code Fast 1 | 262k | Reasoning, code |
-| `kimi-k2-thinking` | Kimi K2 Thinking | 262k | Reasoning |
-| `minimax-m21` | MiniMax M2.1 | 202k | Reasoning |
+| 模型 ID | 原始模型 | 上下文（tokens） | 特性 |
+|---------|---------|-----------------|------|
+| `claude-opus-45` | Claude Opus 4.5 | 202k | 推理、视觉 |
+| `claude-sonnet-45` | Claude Sonnet 4.5 | 202k | 推理、视觉 |
+| `openai-gpt-52` | GPT-5.2 | 262k | 推理 |
+| `openai-gpt-52-codex` | GPT-5.2 Codex | 262k | 推理、视觉 |
+| `gemini-3-pro-preview` | Gemini 3 Pro | 202k | 推理、视觉 |
+| `gemini-3-flash-preview` | Gemini 3 Flash | 262k | 推理、视觉 |
+| `grok-41-fast` | Grok 4.1 Fast | 262k | 推理、视觉 |
+| `grok-code-fast-1` | Grok Code Fast 1 | 262k | 推理、编程 |
+| `kimi-k2-thinking` | Kimi K2 Thinking | 262k | 推理 |
+| `minimax-m21` | MiniMax M2.1 | 202k | 推理 |
 
-## Model Discovery
+## 模型发现
 
-Clawdbot automatically discovers models from the Venice API when `VENICE_API_KEY` is set. If the API is unreachable, it falls back to a static catalog.
+设置 `VENICE_API_KEY` 后，Clawdbot 会自动从 Venice API 发现模型。如果 API 不可达，则回退到静态模型目录。
 
-The `/models` endpoint is public (no auth needed for listing), but inference requires a valid API key.
+`/models` 端点是公开的（列出模型不需要认证），但推理需要有效的 API 密钥。
 
-## Streaming & Tool Support
+## 流式传输和工具支持
 
-| Feature | Support |
-|---------|---------|
-| **Streaming** | ✅ All models |
-| **Function calling** | ✅ Most models (check `supportsFunctionCalling` in API) |
-| **Vision/Images** | ✅ Models marked with "Vision" feature |
-| **JSON mode** | ✅ Supported via `response_format` |
+| 功能 | 支持情况 |
+|------|---------|
+| **流式传输** | 所有模型支持 |
+| **函数调用** | 大部分模型支持（查看 API 中的 `supportsFunctionCalling`） |
+| **视觉/图片** | 标记"视觉"特性的模型支持 |
+| **JSON 模式** | 通过 `response_format` 支持 |
 
-## Pricing
+## 定价
 
-Venice uses a credit-based system. Check [venice.ai/pricing](https://venice.ai/pricing) for current rates:
+Venice 使用积分制。当前费率请查看 [venice.ai/pricing](https://venice.ai/pricing)：
 
-- **Private models**: Generally lower cost
-- **Anonymized models**: Similar to direct API pricing + small Venice fee
+- **私密模型**：通常成本更低
+- **匿名模型**：接近直接 API 定价 + Venice 小额费用
 
-## Comparison: Venice vs Direct API
+## 对比：Venice vs 直接 API
 
-| Aspect | Venice (Anonymized) | Direct API |
-|--------|---------------------|------------|
-| **Privacy** | Metadata stripped, anonymized | Your account linked |
-| **Latency** | +10-50ms (proxy) | Direct |
-| **Features** | Most features supported | Full features |
-| **Billing** | Venice credits | Provider billing |
+| 方面 | Venice（匿名） | 直接 API |
+|------|---------------|---------|
+| **隐私** | 元数据被剥离，匿名化 | 关联您的账户 |
+| **延迟** | +10-50ms（代理） | 直连 |
+| **功能** | 大部分功能支持 | 全部功能 |
+| **计费** | Venice 积分 | 供应商计费 |
 
-## Usage Examples
+## 使用示例
 
 ```bash
-# Use default private model
+# 使用默认私密模型
 clawdbot chat --model venice/llama-3.3-70b
 
-# Use Claude via Venice (anonymized)
+# 通过 Venice 使用 Claude（匿名）
 clawdbot chat --model venice/claude-opus-45
 
-# Use uncensored model
+# 使用无审查模型
 clawdbot chat --model venice/venice-uncensored
 
-# Use vision model with image
+# 使用视觉模型
 clawdbot chat --model venice/qwen3-vl-235b-a22b
 
-# Use coding model
+# 使用编程模型
 clawdbot chat --model venice/qwen3-coder-480b-a35b-instruct
 ```
 
-## Troubleshooting
+## 故障排除
 
-### API key not recognized
+### API 密钥无法识别
 
 ```bash
 echo $VENICE_API_KEY
 openclaw-cn models list | grep venice
 ```
 
-Ensure the key starts with `vapi_`.
+确保密钥以 `vapi_` 开头。
 
-### Model not available
+### 模型不可用
 
-The Venice model catalog updates dynamically. Run `openclaw-cn models list` to see currently available models. Some models may be temporarily offline.
+Venice 模型目录动态更新。运行 `openclaw-cn models list` 查看当前可用模型。部分模型可能临时离线。
 
-### Connection issues
+### 连接问题
 
-Venice API is at `https://api.venice.ai/api/v1`. Ensure your network allows HTTPS connections.
+Venice API 地址为 `https://api.venice.ai/api/v1`。请确保网络允许 HTTPS 连接。
 
-## Config file example
+## 配置文件示例
 
 ```json5
 {
@@ -256,9 +256,9 @@ Venice API is at `https://api.venice.ai/api/v1`. Ensure your network allows HTTP
 }
 ```
 
-## Links
+## 链接
 
 - [Venice AI](https://venice.ai)
-- [API Documentation](https://docs.venice.ai)
-- [Pricing](https://venice.ai/pricing)
-- [Status](https://status.venice.ai)
+- [API 文档](https://docs.venice.ai)
+- [定价](https://venice.ai/pricing)
+- [服务状态](https://status.venice.ai)

--- a/docs/providers/vercel-ai-gateway.md
+++ b/docs/providers/vercel-ai-gateway.md
@@ -1,28 +1,27 @@
 ---
 title: "Vercel AI Gateway"
-summary: "Vercel AI Gateway setup (auth + model selection)"
+summary: "Vercel AI Gateway 配置（认证 + 模型选择）"
 read_when:
-  - You want to use Vercel AI Gateway with Clawdbot
-  - You need the API key env var or CLI auth choice
+  - 您想在 Clawdbot 中使用 Vercel AI Gateway
+  - 您需要 API 密钥环境变量或 CLI 认证选项
 ---
 # Vercel AI Gateway
 
+[Vercel AI Gateway](https://vercel.com/ai-gateway) 提供统一 API，通过单一端点访问数百种模型。
 
-The [Vercel AI Gateway](https://vercel.com/ai-gateway) provides a unified API to access hundreds of models through a single endpoint. 
+- 供应商：`vercel-ai-gateway`
+- 认证：`AI_GATEWAY_API_KEY`
+- API：兼容 Anthropic Messages 格式
 
-- Provider: `vercel-ai-gateway`
-- Auth: `AI_GATEWAY_API_KEY`
-- API: Anthropic Messages compatible
+## 快速开始
 
-## Quick start
-
-1) Set the API key (recommended: store it for the Gateway):
+1) 设置 API 密钥（推荐：为网关存储）：
 
 ```bash
 openclaw-cn onboard --auth-choice ai-gateway-api-key
 ```
 
-2) Set a default model:
+2) 设置默认模型：
 
 ```json5
 {
@@ -34,7 +33,7 @@ openclaw-cn onboard --auth-choice ai-gateway-api-key
 }
 ```
 
-## Non-interactive example
+## 非交互式示例
 
 ```bash
 openclaw-cn onboard --non-interactive \
@@ -43,8 +42,7 @@ openclaw-cn onboard --non-interactive \
   --ai-gateway-api-key "$AI_GATEWAY_API_KEY"
 ```
 
-## Environment note
+## 环境说明
 
-If the Gateway runs as a daemon (launchd/systemd), make sure `AI_GATEWAY_API_KEY`
-is available to that process (for example, in `~/.openclaw/.env` or via
-`env.shellEnv`).
+如果网关以守护进程运行（launchd/systemd），请确保该进程能访问 `AI_GATEWAY_API_KEY`
+（例如写在 `~/.openclaw/.env` 中或通过 `env.shellEnv` 设置）。


### PR DESCRIPTION
## Summary

- 翻译 `docs/providers/` 下 10 个供应商文档为中文
- 国内外调用 baseUrl 一致的文档直接翻译：index、openai、opencode、openrouter、anthropic、github-copilot、venice、vercel-ai-gateway、deepgram
- 国内外 baseUrl 不一致的 moonshot.md：默认 baseUrl 改为国内端点 `api.moonshot.cn`，配置中注释说明海外端点 `api.moonshot.ai`
- moonshot.md 使用 Moonshot（月之暗面）双语写法，与 `docs/guides/custom-ai-providers.md` 中的独立配置说明以及国内月之暗面品牌做出区分
- openrouter.md 补充了 OpenRouter 简介及支持支付宝充值的说明

## Test plan

- [ ] 本地预览确认文档渲染正常
- [ ] 确认所有内部链接可正常跳转
- [ ] 确认代码块中的命令和配置未被误翻译