### PR TITLE
docs: 翻译记忆(memory)文档为中文

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -1,47 +1,41 @@
 ---
-summary: "How Clawdbot memory works (workspace files + automatic memory flush)"
+summary: "Clawdbot 记忆系统的工作原理（工作区文件 + 自动记忆刷新）"
 read_when:
-  - You want the memory file layout and workflow
-  - You want to tune the automatic pre-compaction memory flush
+  - 你想了解记忆文件的布局和工作流程
+  - 你想调整自动压缩前的记忆刷新机制
 ---
-# Memory
+# 记忆
 
-Clawdbot memory is **plain Markdown in the agent workspace**. The files are the
-source of truth; the model only "remembers" what gets written to disk.
+Clawdbot 的记忆是**工作区中的纯 Markdown 文件**。这些文件是唯一的数据来源；模型只会"记住"写入磁盘的内容。
 
-Memory search tools are provided by the active memory plugin (default:
-`memory-core`). Disable memory plugins with `plugins.slots.memory = "none"`.
+记忆搜索工具由当前激活的记忆插件提供（默认：`memory-core`）。可通过 `plugins.slots.memory = "none"` 禁用记忆插件。
 
-## Memory files (Markdown)
+## 记忆文件（Markdown）
 
-The default workspace layout uses two memory layers:
+默认的工作区布局使用两层记忆：
 
 - `memory/YYYY-MM-DD.md`
-  - Daily log (append-only).
-  - Read today + yesterday at session start.
-- `MEMORY.md` (optional)
-  - Curated long-term memory.
-  - **Only load in the main, private session** (never in group contexts).
+  - 每日日志（仅追加）。
+  - 会话开始时读取今天和昨天的日志。
+- `MEMORY.md`（可选）
+  - 精心整理的长期记忆。
+  - **仅在主私人会话中加载**（不会在群组上下文中加载）。
 
-These files live under the workspace (`agents.defaults.workspace`, default
-`~/clawd`). See [Agent workspace](/concepts/agent-workspace) for the full layout.
+这些文件位于工作区目录下（`agents.defaults.workspace`，默认为 `~/clawd`）。完整布局请参阅 [Agent 工作区](/concepts/agent-workspace)。
 
-## When to write memory
+## 何时写入记忆
 
-- Decisions, preferences, and durable facts go to `MEMORY.md`.
-- Day-to-day notes and running context go to `memory/YYYY-MM-DD.md`.
-- If someone says "remember this," write it down (do not keep it in RAM).
-- This area is still evolving. It helps to remind the model to store memories; it will know what to do.
-- If you want something to stick, **ask the bot to write it** into memory.
+- 决策、偏好和持久性事实写入 `MEMORY.md`。
+- 日常笔记和运行上下文写入 `memory/YYYY-MM-DD.md`。
+- 如果有人说"记住这个"，就将其写入文件（不要仅保存在内存中）。
+- 这个功能仍在不断完善中。提醒模型存储记忆会有所帮助；模型会知道该怎么做。
+- 如果你希望某些内容被持久保存，**请让机器人将其写入**记忆文件。
 
-## Automatic memory flush (pre-compaction ping)
+## 自动记忆刷新（压缩前触发）
 
-When a session is **close to auto-compaction**, Clawdbot triggers a **silent,
-agentic turn** that reminds the model to write durable memory **before** the
-context is compacted. The default prompts explicitly say the model *may reply*,
-but usually `NO_REPLY` is the correct response so the user never sees this turn.
+当会话**接近自动压缩**时，Clawdbot 会触发一个**静默的 Agent 轮次**，提醒模型在上下文被压缩**之前**写入持久记忆。默认提示词明确表示模型*可以回复*，但通常 `NO_REPLY` 是正确的响应，这样用户永远不会看到这个轮次。
 
-This is controlled by `agents.defaults.compaction.memoryFlush`:
+此功能通过 `agents.defaults.compaction.memoryFlush` 控制：
 
 ```json5
 {
@@ -61,44 +55,35 @@ This is controlled by `agents.defaults.compaction.memoryFlush`:
 }
 ```
 
-Details:
-- **Soft threshold**: flush triggers when the session token estimate crosses
-  `contextWindow - reserveTokensFloor - softThresholdTokens`.
-- **Silent** by default: prompts include `NO_REPLY` so nothing is delivered.
-- **Two prompts**: a user prompt plus a system prompt append the reminder.
-- **One flush per compaction cycle** (tracked in `sessions.json`).
-- **Workspace must be writable**: if the session runs sandboxed with
-  `workspaceAccess: "ro"` or `"none"`, the flush is skipped.
+详细说明：
+- **软阈值**：当会话 token 估算值超过 `contextWindow - reserveTokensFloor - softThresholdTokens` 时触发刷新。
+- 默认为**静默**模式：提示词包含 `NO_REPLY`，不会向用户发送任何内容。
+- **两段提示**：一个用户提示加一个系统提示共同附加提醒信息。
+- **每个压缩周期仅刷新一次**（在 `sessions.json` 中跟踪）。
+- **工作区必须可写**：如果会话以 `workspaceAccess: "ro"` 或 `"none"` 的沙盒模式运行，则跳过刷新。
 
-For the full compaction lifecycle, see
-[Session management + compaction](/reference/session-management-compaction).
+完整的压缩生命周期请参阅[会话管理 + 压缩](/reference/session-management-compaction)。
 
-## Vector memory search
+## 向量记忆搜索
 
-Clawdbot can build a small vector index over `MEMORY.md` and `memory/*.md` so
-semantic queries can find related notes even when wording differs.
+Clawdbot 可以在 `MEMORY.md` 和 `memory/*.md` 上构建小型向量索引，使语义查询即使在措辞不同时也能找到相关笔记。
 
-Defaults:
-- Enabled by default.
-- Watches memory files for changes (debounced).
-- Uses remote embeddings by default. If `memorySearch.provider` is not set, Clawdbot auto-selects:
-  1. `local` if a `memorySearch.local.modelPath` is configured and the file exists.
-  2. `openai` if an OpenAI key can be resolved.
-  3. `gemini` if a Gemini key can be resolved.
-  4. Otherwise memory search stays disabled until configured.
-- Local mode uses node-llama-cpp and may require `pnpm approve-builds`.
-- Uses sqlite-vec (when available) to accelerate vector search inside SQLite.
+默认配置：
+- 默认启用。
+- 监视记忆文件的变更（带防抖）。
+- 默认使用远程嵌入。如果未设置 `memorySearch.provider`，Clawdbot 会自动选择：
+  1. 如果配置了 `memorySearch.local.modelPath` 且文件存在，使用 `local`。
+  2. 如果能解析到 OpenAI 密钥，使用 `openai`。
+  3. 如果能解析到 Gemini 密钥，使用 `gemini`。
+  4. 否则记忆搜索保持禁用状态，直到完成配置。
+- 本地模式使用 node-llama-cpp，可能需要运行 `pnpm approve-builds`。
+- 当 sqlite-vec 可用时，使用它加速 SQLite 中的向量搜索。
 
-Remote embeddings **require** an API key for the embedding provider. Clawdbot
-resolves keys from auth profiles, `models.providers.*.apiKey`, or environment
-variables. Codex OAuth only covers chat/completions and does **not** satisfy
-embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
-`models.providers.google.apiKey`. When using a custom OpenAI-compatible endpoint,
-set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
+远程嵌入**需要**嵌入提供商的 API 密钥。Clawdbot 从认证配置、`models.providers.*.apiKey` 或环境变量中解析密钥。Codex OAuth 仅覆盖 chat/completions，**不满足**记忆搜索的嵌入需求。对于 Gemini，请使用 `GEMINI_API_KEY` 或 `models.providers.google.apiKey`。使用自定义 OpenAI 兼容端点时，请设置 `memorySearch.remote.apiKey`（以及可选的 `memorySearch.remote.headers`）。
 
-### Gemini embeddings (native)
+### Gemini 嵌入（原生）
 
-Set the provider to `gemini` to use the Gemini embeddings API directly:
+将提供商设置为 `gemini` 以直接使用 Gemini 嵌入 API：
 
 ```json5
 agents: {
@@ -114,13 +99,12 @@ agents: {
 }
 ```
 
-Notes:
-- `remote.baseUrl` is optional (defaults to the Gemini API base URL).
-- `remote.headers` lets you add extra headers if needed.
-- Default model: `gemini-embedding-001`.
+说明：
+- `remote.baseUrl` 是可选的（默认为 Gemini API 基础 URL）。
+- `remote.headers` 允许你在需要时添加额外的请求头。
+- 默认模型：`gemini-embedding-001`。
 
-If you want to use a **custom OpenAI-compatible endpoint** (OpenRouter, vLLM, or a proxy),
-you can use the `remote` configuration with the OpenAI provider:
+如果你想使用**自定义 OpenAI 兼容端点**（OpenRouter、vLLM 或代理），可以使用 OpenAI 提供商的 `remote` 配置：
 
 ```json5
 agents: {
@@ -138,28 +122,27 @@ agents: {
 }
 ```
 
-If you don't want to set an API key, use `memorySearch.provider = "local"` or set
-`memorySearch.fallback = "none"`.
+如果你不想设置 API 密钥，请使用 `memorySearch.provider = "local"` 或设置 `memorySearch.fallback = "none"`。
 
-Fallbacks:
-- `memorySearch.fallback` can be `openai`, `gemini`, `local`, or `none`.
-- The fallback provider is only used when the primary embedding provider fails.
+回退机制：
+- `memorySearch.fallback` 可以是 `openai`、`gemini`、`local` 或 `none`。
+- 回退提供商仅在主嵌入提供商失败时使用。
 
-Batch indexing (OpenAI + Gemini):
-- Enabled by default for OpenAI and Gemini embeddings. Set `agents.defaults.memorySearch.remote.batch.enabled = false` to disable.
-- Default behavior waits for batch completion; tune `remote.batch.wait`, `remote.batch.pollIntervalMs`, and `remote.batch.timeoutMinutes` if needed.
-- Set `remote.batch.concurrency` to control how many batch jobs we submit in parallel (default: 2).
-- Batch mode applies when `memorySearch.provider = "openai"` or `"gemini"` and uses the corresponding API key.
-- Gemini batch jobs use the async embeddings batch endpoint and require Gemini Batch API availability.
+批量索引（OpenAI + Gemini）：
+- 对于 OpenAI 和 Gemini 嵌入，默认启用批量索引。设置 `agents.defaults.memorySearch.remote.batch.enabled = false` 可禁用。
+- 默认行为会等待批处理完成；如需调整，请配置 `remote.batch.wait`、`remote.batch.pollIntervalMs` 和 `remote.batch.timeoutMinutes`。
+- 设置 `remote.batch.concurrency` 控制并行提交的批处理作业数量（默认：2）。
+- 批量模式在 `memorySearch.provider = "openai"` 或 `"gemini"` 时适用，并使用对应的 API 密钥。
+- Gemini 批处理作业使用异步嵌入批处理端点，需要 Gemini Batch API 可用。
 
-Why OpenAI batch is fast + cheap:
-- For large backfills, OpenAI is typically the fastest option we support because we can submit many embedding requests in a single batch job and let OpenAI process them asynchronously.
-- OpenAI offers discounted pricing for Batch API workloads, so large indexing runs are usually cheaper than sending the same requests synchronously.
-- See the OpenAI Batch API docs and pricing for details:
+为什么 OpenAI 批处理既快又便宜：
+- 对于大规模回填，OpenAI 通常是我们支持的最快选项，因为我们可以在单个批处理作业中提交大量嵌入请求，让 OpenAI 异步处理。
+- OpenAI 为 Batch API 工作负载提供折扣定价，因此大规模索引通常比同步发送相同请求更便宜。
+- 详情请参阅 OpenAI Batch API 文档和定价：
   - https://platform.openai.com/docs/api-reference/batch
   - https://platform.openai.com/pricing
 
-Config example:
+配置示例：
 
 ```json5
 agents: {
@@ -177,75 +160,71 @@ agents: {
 }
 ```
 
-Tools:
-- `memory_search` — returns snippets with file + line ranges.
-- `memory_get` — read memory file content by path.
+工具：
+- `memory_search` — 返回包含文件路径和行范围的片段。
+- `memory_get` — 通过路径读取记忆文件内容。
 
-Local mode:
-- Set `agents.defaults.memorySearch.provider = "local"`.
-- Provide `agents.defaults.memorySearch.local.modelPath` (GGUF or `hf:` URI).
-- Optional: set `agents.defaults.memorySearch.fallback = "none"` to avoid remote fallback.
+本地模式：
+- 设置 `agents.defaults.memorySearch.provider = "local"`。
+- 提供 `agents.defaults.memorySearch.local.modelPath`（GGUF 或 `hf:` URI）。
+- 可选：设置 `agents.defaults.memorySearch.fallback = "none"` 以避免远程回退。
 
-### How the memory tools work
+### 记忆工具的工作原理
 
-- `memory_search` semantically searches Markdown chunks (~400 token target, 80-token overlap) from `MEMORY.md` + `memory/**/*.md`. It returns snippet text (capped ~700 chars), file path, line range, score, provider/model, and whether we fell back from local → remote embeddings. No full file payload is returned.
-- `memory_get` reads a specific memory Markdown file (workspace-relative), optionally from a starting line and for N lines. Paths outside `MEMORY.md` / `memory/` are rejected.
-- Both tools are enabled only when `memorySearch.enabled` resolves true for the agent.
+- `memory_search` 对来自 `MEMORY.md` + `memory/**/*.md` 的 Markdown 块（目标约 400 token，80 token 重叠）进行语义搜索。返回片段文本（上限约 700 字符）、文件路径、行范围、评分、提供商/模型，以及是否从本地回退到了远程嵌入。不返回完整文件内容。
+- `memory_get` 读取特定的记忆 Markdown 文件（工作区相对路径），可选从指定行开始读取 N 行。拒绝 `MEMORY.md` / `memory/` 之外的路径。
+- 两个工具仅在 Agent 的 `memorySearch.enabled` 解析为 true 时启用。
 
-### What gets indexed (and when)
+### 索引内容（及时机）
 
-- File type: Markdown only (`MEMORY.md`, `memory/**/*.md`).
-- Index storage: per-agent SQLite at `~/.openclaw/memory/<agentId>.sqlite` (configurable via `agents.defaults.memorySearch.store.path`, supports `{agentId}` token).
-- Freshness: watcher on `MEMORY.md` + `memory/` marks the index dirty (debounce 1.5s). Sync is scheduled on session start, on search, or on an interval and runs asynchronously. Session transcripts use delta thresholds to trigger background sync.
-- Reindex triggers: the index stores the embedding **provider/model + endpoint fingerprint + chunking params**. If any of those change, Clawdbot automatically resets and reindexes the entire store.
+- 文件类型：仅 Markdown（`MEMORY.md`、`memory/**/*.md`）。
+- 索引存储：每个 Agent 的 SQLite 文件位于 `~/.openclaw/memory/<agentId>.sqlite`（可通过 `agents.defaults.memorySearch.store.path` 配置，支持 `{agentId}` 占位符）。
+- 新鲜度：监视 `MEMORY.md` + `memory/` 的变更并标记索引为脏数据（防抖 1.5 秒）。同步在会话开始时、搜索时或按间隔调度，异步运行。会话记录使用增量阈值触发后台同步。
+- 重建索引触发条件：索引存储嵌入的**提供商/模型 + 端点指纹 + 分块参数**。如果其中任何一项发生变化，Clawdbot 会自动重置并重新索引整个存储。
 
-### Hybrid search (BM25 + vector)
+### 混合搜索（BM25 + 向量）
 
-When enabled, Clawdbot combines:
-- **Vector similarity** (semantic match, wording can differ)
-- **BM25 keyword relevance** (exact tokens like IDs, env vars, code symbols)
+启用后，Clawdbot 结合以下两种搜索方式：
+- **向量相似度**（语义匹配，措辞可以不同）
+- **BM25 关键词相关性**（精确匹配 token，如 ID、环境变量、代码符号）
 
-If full-text search is unavailable on your platform, Clawdbot falls back to vector-only search.
+如果你的平台不支持全文搜索，Clawdbot 会回退到纯向量搜索。
 
-#### Why hybrid?
+#### 为什么使用混合搜索？
 
-Vector search is great at “this means the same thing”:
-- “Mac Studio gateway host” vs “the machine running the gateway”
-- “debounce file updates” vs “avoid indexing on every write”
+向量搜索擅长"这表达的是同一个意思"：
+- "Mac Studio 网关主机" vs "运行网关的机器"
+- "防抖文件更新" vs "避免每次写入都索引"
 
-But it can be weak at exact, high-signal tokens:
-- IDs (`a828e60`, `b3b9895a…`)
-- code symbols (`memorySearch.query.hybrid`)
-- error strings (“sqlite-vec unavailable”)
+但对于精确的高信号 token，它可能表现较弱：
+- ID（`a828e60`、`b3b9895a…`）
+- 代码符号（`memorySearch.query.hybrid`）
+- 错误字符串（"sqlite-vec unavailable"）
 
-BM25 (full-text) is the opposite: strong at exact tokens, weaker at paraphrases.
-Hybrid search is the pragmatic middle ground: **use both retrieval signals** so you get
-good results for both “natural language” queries and “needle in a haystack” queries.
+BM25（全文搜索）恰好相反：精确 token 匹配能力强，释义匹配能力弱。混合搜索是务实的折中方案：**同时使用两种检索信号**，使"自然语言"查询和"大海捞针"查询都能获得良好的结果。
 
-#### How we merge results (the current design)
+#### 如何合并结果（当前设计）
 
-Implementation sketch:
+实现概述：
 
-1) Retrieve a candidate pool from both sides:
-- **Vector**: top `maxResults * candidateMultiplier` by cosine similarity.
-- **BM25**: top `maxResults * candidateMultiplier` by FTS5 BM25 rank (lower is better).
+1) 从两端检索候选池：
+- **向量**：按余弦相似度取前 `maxResults * candidateMultiplier` 个结果。
+- **BM25**：按 FTS5 BM25 排名取前 `maxResults * candidateMultiplier` 个结果（排名值越低越好）。
 
-2) Convert BM25 rank into a 0..1-ish score:
+2) 将 BM25 排名转换为 0..1 范围的评分：
 - `textScore = 1 / (1 + max(0, bm25Rank))`
 
-3) Union candidates by chunk id and compute a weighted score:
+3) 按 chunk id 合并候选项并计算加权评分：
 - `finalScore = vectorWeight * vectorScore + textWeight * textScore`
 
-Notes:
-- `vectorWeight` + `textWeight` is normalized to 1.0 in config resolution, so weights behave as percentages.
-- If embeddings are unavailable (or the provider returns a zero-vector), we still run BM25 and return keyword matches.
-- If FTS5 can’t be created, we keep vector-only search (no hard failure).
+说明：
+- `vectorWeight` + `textWeight` 在配置解析时归一化为 1.0，因此权重表现为百分比。
+- 如果嵌入不可用（或提供商返回零向量），仍会运行 BM25 并返回关键词匹配结果。
+- 如果无法创建 FTS5，则保持纯向量搜索（不会硬性失败）。
 
-This isn’t “IR-theory perfect”, but it’s simple, fast, and tends to improve recall/precision on real notes.
-If we want to get fancier later, common next steps are Reciprocal Rank Fusion (RRF) or score normalization
-(min/max or z-score) before mixing.
+这并非"信息检索理论上的完美方案"，但它简单、快速，且在实际笔记上往往能提升召回率/精确率。如果将来需要更精细的方案，常见的下一步是倒数排名融合（RRF）或在混合前进行评分归一化（最小/最大值或 z-score）。
 
-Config:
+配置：
 
 ```json5
 agents: {
@@ -264,11 +243,11 @@ agents: {
 }
 ```
 
-### Embedding cache
+### 嵌入缓存
 
-Clawdbot can cache **chunk embeddings** in SQLite so reindexing and frequent updates (especially session transcripts) don't re-embed unchanged text.
+Clawdbot 可以在 SQLite 中缓存**块嵌入**，这样重建索引和频繁更新（尤其是会话记录）就不需要重新嵌入未更改的文本。
 
-Config:
+配置：
 
 ```json5
 agents: {
@@ -283,10 +262,9 @@ agents: {
 }
 ```
 
-### Session memory search (experimental)
+### 会话记忆搜索（实验性）
 
-You can optionally index **session transcripts** and surface them via `memory_search`.
-This is gated behind an experimental flag.
+你可以选择索引**会话记录**并通过 `memory_search` 查询它们。此功能受实验性标志控制。
 
 ```json5
 agents: {
@@ -299,15 +277,15 @@ agents: {
 }
 ```
 
-Notes:
-- Session indexing is **opt-in** (off by default).
-- Session updates are debounced and **indexed asynchronously** once they cross delta thresholds (best-effort).
-- `memory_search` never blocks on indexing; results can be slightly stale until background sync finishes.
-- Results still include snippets only; `memory_get` remains limited to memory files.
-- Session indexing is isolated per agent (only that agent’s session logs are indexed).
-- Session logs live on disk (`~/.openclaw/agents/<agentId>/sessions/*.jsonl`). Any process/user with filesystem access can read them, so treat disk access as the trust boundary. For stricter isolation, run agents under separate OS users or hosts.
+说明：
+- 会话索引是**可选功能**（默认关闭）。
+- 会话更新经过防抖处理，在超过增量阈值后**异步索引**（尽力而为）。
+- `memory_search` 不会阻塞等待索引完成；在后台同步完成之前，结果可能略有滞后。
+- 结果仍然只包含片段；`memory_get` 仍仅限于记忆文件。
+- 会话索引按 Agent 隔离（仅索引该 Agent 的会话日志）。
+- 会话日志存储在磁盘上（`~/.openclaw/agents/<agentId>/sessions/*.jsonl`）。任何具有文件系统访问权限的进程/用户都可以读取它们，因此磁盘访问即为信任边界。如需更严格的隔离，请在不同的操作系统用户或主机下运行 Agent。
 
-Delta thresholds (defaults shown):
+增量阈值（以下为默认值）：
 
 ```json5
 agents: {
@@ -316,7 +294,7 @@ agents: {
       sync: {
         sessions: {
           deltaBytes: 100000,   // ~100 KB
-          deltaMessages: 50     // JSONL lines
+          deltaMessages: 50     // JSONL 行数
         }
       }
     }
@@ -324,13 +302,11 @@ agents: {
 }
 ```
 
-### SQLite vector acceleration (sqlite-vec)
+### SQLite 向量加速（sqlite-vec）
 
-When the sqlite-vec extension is available, Clawdbot stores embeddings in a
-SQLite virtual table (`vec0`) and performs vector distance queries in the
-database. This keeps search fast without loading every embedding into JS.
+当 sqlite-vec 扩展可用时，Clawdbot 将嵌入存储在 SQLite 虚拟表（`vec0`）中，并在数据库内执行向量距离查询。这使搜索保持高速，无需将所有嵌入加载到 JS 中。
 
-Configuration (optional):
+配置（可选）：
 
 ```json5
 agents: {
@@ -347,22 +323,20 @@ agents: {
 }
 ```
 
-Notes:
-- `enabled` defaults to true; when disabled, search falls back to in-process
-  cosine similarity over stored embeddings.
-- If the sqlite-vec extension is missing or fails to load, Clawdbot logs the
-  error and continues with the JS fallback (no vector table).
-- `extensionPath` overrides the bundled sqlite-vec path (useful for custom builds
-  or non-standard install locations).
+说明：
+- `enabled` 默认为 true；禁用时，搜索回退到进程内的余弦相似度计算。
+- 如果 sqlite-vec 扩展缺失或加载失败，Clawdbot 会记录错误并继续使用 JS 回退方案（无向量表）。
+- `extensionPath` 覆盖内置的 sqlite-vec 路径（适用于自定义构建或非标准安装位置）。
 
-### Local embedding auto-download
+### 本地嵌入自动下载
 
-- Default local embedding model: `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` (~0.6 GB).
-- When `memorySearch.provider = "local"`, `node-llama-cpp` resolves `modelPath`; if the GGUF is missing it **auto-downloads** to the cache (or `local.modelCacheDir` if set), then loads it. Downloads resume on retry.
-- Native build requirement: run `pnpm approve-builds`, pick `node-llama-cpp`, then `pnpm rebuild node-llama-cpp`.
-- Fallback: if local setup fails and `memorySearch.fallback = "openai"`, we automatically switch to remote embeddings (`openai/text-embedding-3-small` unless overridden) and record the reason.
+- 默认本地嵌入模型：`hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf`（约 0.6 GB）。
+- 当 `memorySearch.provider = "local"` 时，`node-llama-cpp` 解析 `modelPath`；如果 GGUF 文件缺失，会**自动下载**到缓存目录（或 `local.modelCacheDir`（如果已设置）），然后加载。下载支持断点续传。
+- **注意**：自动下载仅在显式设置 `provider: "local"` 时生效。默认的 `auto` 模式要求本地模型文件已存在，不会触发自动下载。如果你没有配置任何 API 密钥，且希望免费使用记忆搜索，请将 provider 显式设为 `"local"`。
+- 原生构建要求：运行 `pnpm approve-builds`，选择 `node-llama-cpp`，然后执行 `pnpm rebuild node-llama-cpp`。
+- 回退：如果本地设置失败且 `memorySearch.fallback = "openai"`，将自动切换到远程嵌入（默认 `openai/text-embedding-3-small`，除非有覆盖配置），并记录原因。
 
-### Custom OpenAI-compatible endpoint example
+### 自定义 OpenAI 兼容端点示例
 
 ```json5
 agents: {
@@ -383,6 +357,6 @@ agents: {
 }
 ```
 
-Notes:
-- `remote.*` takes precedence over `models.providers.openai.*`.
-- `remote.headers` merge with OpenAI headers; remote wins on key conflicts. Omit `remote.headers` to use the OpenAI defaults.
+说明：
+- `remote.*` 的优先级高于 `models.providers.openai.*`。
+- `remote.headers` 与 OpenAI 请求头合并；冲突时 remote 优先。省略 `remote.headers` 则使用 OpenAI 默认值。


### PR DESCRIPTION
## Summary
- 将 `docs/concepts/memory.md` 全文翻译为中文，保留所有代码块、配置示例和链接
- 在"本地嵌入自动下载"一节补充了一条注意事项

## 需要 Review 的内容

在"本地嵌入自动下载"一节新增了以下提醒（非原文翻译，是基于代码分析后补充的说明）：

> **注意**：自动下载仅在显式设置 `provider: "local"` 时生效。默认的 `auto` 模式要求本地模型文件已存在，不会触发自动下载。如果你没有配置任何 API 密钥，且希望免费使用记忆搜索，请将 provider 显式设为 `"local"`。

**背景分析**：默认 `provider: "auto"` 的选择逻辑中，`canAutoSelectLocal()` 要求本地模型文件已经存在于本地路径（不接受 `hf:` 远程 URL），所以 auto 模式下不会触发 node-llama-cpp 的自动下载。只有显式设置 `provider: "local"` 才会走 `createLocalEmbeddingProvider()`，此时 `resolveModelFile()` 才会自动从 HuggingFace 下载模型。

请确认这条补充说明是否准确、是否适合放在文档中。

## Test plan
- [ ] 确认补充的本地嵌入注意事项与代码行为一致