### PR TITLE
fix(feishu): 流式卡片失败时 fallback 到普通消息

### DIFF
--- a/src/feishu/message.ts
+++ b/src/feishu/message.ts
@@ -492,17 +492,19 @@ export async function processFeishuMessage(
         const hasMedia = payload.mediaUrl || (payload.mediaUrls && payload.mediaUrls.length > 0);
         if (!payload.text && !hasMedia) return;
 
-        // Block replies are now handled by onPartialReply with chunking/throttling
-        // Skip block payloads here to avoid duplicate updates
-        if (info?.kind === "block") return;
+        // Block replies are handled by onPartialReply with chunking/throttling
+        // Only skip block payloads when streaming is active (otherwise they need normal delivery)
+        if (info?.kind === "block" && streamingSession?.isActive()) return;
 
         // If streaming was active, close it with the final text
         if (streamingSession?.isActive() && info?.kind === "final") {
           // Use payload.text if available, otherwise fallback to lastPartialText
           const finalText = payload.text || lastPartialText;
-          await streamingSession.close(finalText);
+          const closed = await streamingSession.close(finalText);
           streamingStarted = false;
-          return; // Card already contains the final text
+          if (closed) return; // Card successfully contains the final text
+          // Streaming card failed — fall through to send as regular message
+          logger.warn("Streaming card close failed, falling back to regular message");
         }
 
         // Handle media URLs


### PR DESCRIPTION
## Summary

修复飞书自动回复收不到消息的问题（#56）。

**根因**：当流式卡片（CardKit API）操作失败时，`deliver` 回调静默丢弃回复，不会 fallback 到普通消息 API。

**三处修改**：
- `streaming-card.ts`：`close()` 和 `closeStreamingMode()` 返回 `boolean` 表示成功/失败
- `message.ts`：streaming close 失败时 fallback 到 `sendMessageFeishu()` 发送普通消息
- `message.ts`：block skip 改为仅在 streaming 活跃时跳过（避免非 streaming 模式下丢弃 block 回复）

**短期临时方案**：设置 `channels.feishu.streaming = false` 关闭流式传输，所有回复走普通消息 API。

## 后续可选增强

1. **`updateStreamingCardText` 返回 `boolean`** — 目前中间流式更新失败只 warn 不 throw，对丢帧场景合理，但如需更细粒度监控可以改
2. **补充 `streaming-card.test.ts`** — 目前无单测，可补一个验证 `close()` 在 API 失败时返回 `false` 的测试

## Test plan

- [ ] 流式卡片正常时：回复通过卡片投递（行为不变）
- [ ] 流式卡片 API 失败时：自动 fallback 到普通文本消息
- [ ] `streaming: false` 时：block 回复不被跳过，正常投递
- [ ] `pnpm build` 通过

Closes #56