### PR TITLE
fix(cron): inject currentChannelId so message tool uses job delivery target

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -354,6 +354,8 @@ export async function runCronIsolatedAgentTurn(params: {
           sessionKey: agentSessionKey,
           messageChannel,
           agentAccountId: resolvedDelivery.accountId,
+          // Inject job delivery target so message tool defaults to the configured channel when AI omits channel/to
+          currentChannelId: resolvedDelivery.to ?? undefined,
           sessionFile,
           workspaceDir,
           config: cfgWithAgentDefaults,


### PR DESCRIPTION
## 问题

在 cron **isolated** 任务中，当 agent 调用 `message` 工具发送结果时，若未显式传 `channel`/`to`，会报错 `Action send requires a target`。agent 随后会通过解析「当前」投递目标（例如最近活跃会话）来重试，可能得到的是私聊而非任务配置的群聊，导致本应发到群组的消息发到了错误目标。

## 修改

在 `runCronIsolatedAgentTurn` 调用 `runEmbeddedPiAgent` 时，将 job 的投递目标注入为 `currentChannelId: resolvedDelivery.to`。这样 message 工具在未传 target 时会使用 `toolContext.currentChannelId`（已有逻辑），即任务配置的 channel，从而稳定发到正确群聊。

## 影响

- 仅影响 cron isolated 任务；当 job 配置了 `payload.channel` / `payload.to` 时，agent 内 message 工具未传 target 会默认使用该目标。
- 不改变已有「显式传 channel/to 时」的行为。

Made with [Cursor](https://cursor.com)