### PR TITLE
fix(scripts/ui.js): 添加 shell: true 解决spawn EINVAL错误

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -55,6 +55,7 @@ function run(cmd, args) {
     cwd: uiDir,
     stdio: "inherit",
     env: process.env,
+    shell: true,
   });
   child.on("exit", (code, signal) => {
     if (signal) process.exit(1);


### PR DESCRIPTION
### 描述  
在 Windows 上运行 `pnpm ui:build` 时，由于 `child_process.spawn` 直接调用 `pnpm.cmd` 批处理文件，且未设置 `shell: true` 选项，导致 `spawn EINVAL` 错误，构建失败。  

本 PR 在 `scripts/ui.js` 的 `run` 函数中为 `spawn` 调用添加了 `{ shell: true }` 选项。这一修改使 Windows 能通过系统 shell 正确解析并执行 `.cmd` 命令，同时不会影响 Linux/macOS 等其他平台的正常执行。

### 测试说明  
- **环境**：Windows 11 + Node.js v22.22.0  
- **测试步骤**：  
  1. 在项目根目录打开终端  
  2. 运行 `pnpm ui:build`  
  3. 观察构建过程是否正常完成  

### 截图  
**修改前**  
<img width="869" height="507" alt="70eacd033fed6ab61f86f762aaadff25" src="https://github.com/user-attachments/assets/9e2138ba-0976-4136-a0ed-ca2ad68f7798" />


**修改后**  
<img width="869" height="450" alt="image" src="https://github.com/user-attachments/assets/3b77d34e-614f-463f-9fa1-033a57dfd47a" />


### 检查清单  
- [x] 代码遵循项目风格  
- [x] 已在 Windows 本地测试通过  
- [x] 提交信息符合规范  
